### PR TITLE
Clarify "tokens" in mC4

### DIFF
--- a/mc4/README.md
+++ b/mc4/README.md
@@ -2,8 +2,7 @@
 
 This was the data used to train [mT5](https://arxiv.org/abs/2010.11934). These numbers came from Table 5 in the mT5 paper.
 
-I don't know what "tokens" refers to -- whether it is whitespace-delineated words, or byte-pair encoded tokens.
-
+"Tokens" refers to tokens produced by the [released SentencePiece model](https://console.cloud.google.com/storage/browser/t5-data/vocabs/mc4.250000.100extra?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false).
 This data can be found [here](https://www.tensorflow.org/datasets/catalog/c4#c4multilingual). I have not validated the data
 sizes against the table.
 


### PR DESCRIPTION
The tokens in mC4 are tokens produced by the SentencePiece model we released. I don't think anyone should use "tokens" to refer to "whitespace-delineated words", given that there are many languages that do not delimit words with whitespace.